### PR TITLE
Minor Performance Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,3 @@ description = "Geohash library"
 
 [dependencies]
 rand = "0.7"
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,12 +135,13 @@ pub fn bounding_box_int_with_precision(hash: u64, bits: usize) -> Box {
     let lat = decode_range!(lat_int, 90.0);
     let lng = decode_range!(lng_int, 180.0);
     let (lat_err, lng_err) = error_with_precision(bits);
-    Box {
+    let b = Box {
         min_lat: lat,
         max_lat: lat + lat_err,
         min_lng: lng,
         max_lng: lng + lng_err,
-    }
+    };
+    b
 }
 
 /// bounding_box_int returns the region encoded by the given 64-bit integer


### PR DESCRIPTION
I was playing around with the crate and curious how I might get it to go faster. I converted some of the functions to macros after running base benchmarks and benchmarked afterwards. Seemed to have improved performance. 

Here's the code I'm using to benchmark:

```go
extern crate rand;

use tidwall_geohash as geohash;
use rand::Rng;

/// generate_points
fn generate_points(size: usize) -> Vec<(f64, f64)> {
    let mut rng = rand::thread_rng();
    (0..size)
        .map(|_| (rng.gen::<f64>(), rng.gen::<f64>()))
        .collect()
}

/// generate_hashes
fn generate_hashes(size: usize) -> Vec<String> {
    generate_points(size)
        .iter()
        .map(|p| geohash::encode(p.0, p.1))
        .collect()
}

fn convert_points_to_hashes(points: Vec<(f64, f64)>) -> Vec<String> {
    points
    .iter()
    .map(|p| geohash::encode(p.0, p.1))
    .collect()
}

fn main() {
    let ops: usize = 10_000_000;

    let points = generate_points(ops);
    println!("running encoding benchmark...");
    lotsa::ops(ops-1, 1, |i, _| {
        geohash::encode(points[i].0, points[i].1);
    });

    let hashes = convert_points_to_hashes(points);
    println!("running decoding benchmark...");
    lotsa::ops(ops-1, 1, |i, _| {
        geohash::decode(&hashes[i]);
    });
}
```

```sh
running encoding benchmark...
9,999,999 ops in 10138ms, 986,313/sec, 1013 ns/op
running decoding benchmark...
9,999,999 ops in 5244ms, 1,906,833/sec, 524 ns/op
```

Feel free to kill this PR if flawed, or otherwise useless.
